### PR TITLE
No newline on the website for some reason

### DIFF
--- a/src/tuscan-style-pork-roast.md
+++ b/src/tuscan-style-pork-roast.md
@@ -1,7 +1,7 @@
 # Tuscan Style Pork Roast
 
 An herbaceous pancetta stuffed pork roast with a crispy exterior. Finished with a lemon vinaigrette.
-Adapted from [Binging With Babish](https://www.youtube.com/watch?v=AgFaljoriYA) whose instructions are notoriously bad
+Adapted from [Binging With Babish](https://www.youtube.com/watch?v=AgFaljoriYA) whose instructions are notoriously bad.
 
 - Prep time: 30 minutes
 - Cook time: 2 hours


### PR DESCRIPTION
This is trying to fix the prep time list. It's not working on the website