### PR TITLE
Remove page margin when printing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -33,3 +33,9 @@ img {
 		color: tomato ;
 	}
 }
+
+@media print {
+	body {
+		max-width: none ;
+	}
+}


### PR DESCRIPTION
I personally prefer this when printed on paper.

Examples:
before: [https://0x0.st/-ZBB.pdf](https://0x0.st/-ZBB.pdf)
after: [https://0x0.st/-ZBu.pdf](https://0x0.st/-ZBu.pdf)