### PR TITLE
Fix GitHub url on homepage

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -39,7 +39,7 @@ Founded to provide a simple online cookbook without ads and obese web design.
 
 ### It's easy to contribute!
 
-- Submit new recipes via git via [Github](https://github.com/lukesmithxyz/based.recipes) or [Gitlab](https://gitlab.com/lukesmithxyz/based.cooking).
+- Submit new recipes via git via [Github](https://github.com/lukesmithxyz/based.cooking) or [Gitlab](https://gitlab.com/lukesmithxyz/based.cooking).
 - If a recipe has no image for it, make the recipe as presented and submit a picture above or to [luke@lukesmith.xyz](mailto:luke@lukesmith.xyz).
 - Donate to the individual people who contribute pages whose names are at the bottom of each page.
 - Donate Bitcoin to the site's long-term maintenance fund: `bc1q763s4ud0hgfa66ce64gyh6tsss49vyk5cqcm6w` ([QR code](pix/bitcoin-based-cooking.webp))


### PR DESCRIPTION
Previously linked to lukesmithxyz/based.recipes, which does not exist.