### PR TITLE
Remove hyperlinks when printing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -34,3 +34,10 @@ img {
 		color: tomato ;
 	}
 }
+
+@media print {
+	a[href] {
+		text-decoration: none ;
+		color: black ;
+	}
+}


### PR DESCRIPTION
Removes the blue colour and underlining from hyperlinks when printing the page.

before: [http://0x0.st/-ZBB.pdf](http://0x0.st/-ZBB.pdf)
after: [http://0x0.st/-ZjZ.pdf](http://0x0.st/-ZjZ.pdf)