### PR TITLE
Add .ssgignore and ignore template.md

### DIFF
--- a/src/.ssgignore
+++ b/src/.ssgignore
@@ -1,0 +1,1 @@
+template.md

--- a/src/example.md
+++ b/src/example.md
@@ -1,5 +1,0 @@
-# Example page
-
-Here is an example page.
-
-Will this be added.


### PR DESCRIPTION
https://based.cooking/template.html should no longer be generated.

Also, removed example.md since it looked like a leftover from testing.