### PR TITLE
Fixes matcha cookies listing

### DIFF
--- a/src/matcha-cookies.md
+++ b/src/matcha-cookies.md
@@ -2,19 +2,20 @@
 
 Matcha is a type of tea leaf powder that has a beautiful vivid green color. However, it’s different from the “green tea” that you drink with Japanese meals. That’s green tea too, but matcha green tea leaves are grown and harvested differently. The leaves are grown under shade.
 
-## Ingredients 
+## Ingredients
 (for 13 cookies, 8 ~ 9cm in diameter)
-115 g Unsalted butter
-60g Caster sugar
-115g Brown sugar
-55g Egg
-153g Plain flour
-12g Matcha powder
-2g Baking soda
-1g Salt
-3g Vanilla extract
-70g White coverture chocolate 
-45g Macadamia nut
+
+- 115 g Unsalted butter
+- 60g Caster sugar
+- 115g Brown sugar
+- 55g Egg
+- 153g Plain flour
+- 12g Matcha powder
+- 2g Baking soda
+- 1g Salt
+- 3g Vanilla extract
+- 70g White coverture chocolate
+- 45g Macadamia nut
 
 ## Directions
 1. Melt butter in a bath or microwave.
@@ -22,11 +23,11 @@ Matcha is a type of tea leaf powder that has a beautiful vivid green color. Howe
 3. Add egg and vanilla extract and mix with a whisk until well mixed.
 4. Add flour, matcha powder and baking soda and mix with a whisk until you can hardly see the powder.
 5. Add white coverture chocolate  and macadamia and mix evenly with spatula.
-6. Allow 30 minutes to 1 hour in the refrigerator until the dough hardens. 
+6. Allow 30 minutes to 1 hour in the refrigerator until the dough hardens.
 7. Pan with a 5cm diameter cookie and bake at 170 ° C for 9 minutes. (Unox convection oven)
 
 * Preheat the oven beforehand. My oven is very hot, so raise the oven temperature a little bit higher if you have common oven.
-* If you bake too little, it will not be cooked. If you bake too long, it will become hard. 
+* If you bake too little, it will not be cooked. If you bake too long, it will become hard.
 * The white coverture chocolate melts smoothly in your mouth, and the white chocolate chip has a more chewy texture. So you can choose anything to your taste.
 
 ## Contribution


### PR DESCRIPTION
Ingredients weren't in an unordered list. Rendered them as one long line.
Seems like I also deleted some trailing whitespaces.