### PR TITLE
Add PR template with index reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+If you're submitting a recipe, remember to:
+
+1. Add it to the index
+2. Follow all [submission guidelines](https://github.com/LukeSmithxyz/based.cooking#rules-for-submission)
+
+(feel free to remove this text from your PR once you've reviewed the checklist)


### PR DESCRIPTION
This will place a reminder to review submission guidelines (in particular, to add one's recipe to the index) when creating a PR.