### PR TITLE
Disable deployments on PR creation

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,13 +1,9 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push to master (including merged PRs)
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
I'm pretty sure the `on: pull_request` event means deployments would be attempted from each PR, even before they're merged into master. Just having `on: push` should capture both direct pushes and PR merges to master. [Reference](https://stackoverflow.com/a/61565445/7406283).