### PR TITLE
fixed sticky pork hyperlink issue from japanese noodle soup and replaced duplicate description

### DIFF
--- a/src/japanese-noodle-soup.md
+++ b/src/japanese-noodle-soup.md
@@ -32,7 +32,7 @@ This is a very easy and simple Japanese style ramen noodle soup. This is very ch
 1. For the broth, add 700ml of chicken stock to a large boiling pot with the garlic, ginger, soy sauce, chinese five spice, chili, and 300ml of water.
 2. Bring this to the boil, then turn the heat to low and simmer for around 5 mins.
 3. Add a pinch of sugar and more soy sauce to taste
-4. Fry the pork chops until cooked (My [Sticky Pork Chops]("https://based.cooking/sticky-porkchops") recepie works really well with this dish)
+4. Fry the pork chops until cooked (My [Sticky Pork Chops](https://based.cooking/sticky-porkchops) recepie works really well with this dish)
 5. Hard boil 4 eggs.
 6. Cook the ramen noodles as per packet instructions.
 7. Strain the stock into another pan, then reheat.

--- a/src/sticky-porkchops.md
+++ b/src/sticky-porkchops.md
@@ -1,6 +1,6 @@
 # Sticky Porkchops
 
-This is a very easy and simple Japanese style ramen noodle soup. This is very cheap to make, and you can really customise this however you wish with the garnish. This is my own spin inspired by other recipies that I found.
+Simple chinese inspired sticky porkchops.
 
 - ⏲️ Prep time: 3 hours
 - 🍳Cook time: 10 min


### PR DESCRIPTION
<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hypens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- **ADD YOUR RECIPE TO THE LIST ON `index.md` OR NO ONE WILL EVER SEE IT.**
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
