### PR TITLE
spelling conform to new title

### DIFF
--- a/src/pork-based-chili-con-carne.md
+++ b/src/pork-based-chili-con-carne.md
@@ -12,8 +12,8 @@ Mince should be broken up well before cooking.
 - Chorizo pork sausage
 - Pork mince
 - Bacon strips
-- Tomato sauce
-- Chilis
+- Tomatoe sauce
+- Chillis
 - Kidney beans
 - Olive oil
 - Wine
@@ -22,13 +22,13 @@ Mince should be broken up well before cooking.
 
 ## Directions
 
-1. As pan heats: Slice chilis and chorizo as desired
+1. As pan heats: Slice chillis and chorizo as desired
 2. Olive oil in pan heat on high
 3. Pork mince in.
 3. Butter add
 4. Bacon add
 5. Add 3/4 of tomato sauce
-6. Add chilis and chorizo
+6. Add chillis and chorizo
 7. Add spices and beans. Then wait until audible spitting of sauce has lasted for around 40 min
 8. Add remainder of sauce
 9. Add wine


### PR DESCRIPTION
England-English spelling conformity in suit with title change. ( from 'pork based chili-con-carne' to 'chilli-con-carne', presumably chosen to distinguish it from the other chilli recipe without need of a long title. ) It just bugs me that the spelling is 'Chilli' but the use of it on the page is 'Chili'.