### PR TITLE
Fixed Image sizing for directional images

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -25,7 +25,8 @@ code {
 	color: lime ;
 }
 
-li img {
+img[alt="BTC logo"],
+img[alt="XMR Logo"] {
 	max-width: 1em ;
 	max-height: 1em ;
 	display: inline ;


### PR DESCRIPTION
The `li img` selector looks like it was meant to target the bitcoin and monero icons on the homepage, but it is also targeting images that people have put at certain steps of recipe directions.

I have Updated the css selector to be more specific so that it won't target directional images on recipe pages anymore.

Example page: https://based.cooking/stuffed-round-squash (note the really small images at the end of directions 1 and 2).