### PR TITLE
Fix relative link

### DIFF
--- a/src/fish-curry.md
+++ b/src/fish-curry.md
@@ -29,6 +29,6 @@ Best served with white rice
 
 
 ## Contribution
-- Thijs Wester - [website](twester.tk)
+- Thijs Wester - [website](https://twester.tk)
 
 ;tags: thai

--- a/src/tomato-and-grilled-paprika-soup.md
+++ b/src/tomato-and-grilled-paprika-soup.md
@@ -28,6 +28,6 @@ Can be prepared the night before and kept frozen for a week or two.
 5. Add spices, syrup and cream.
 
 ## Contribution
-- Thijs Wester - [website](twester.tk)
+- Thijs Wester - [website](https://twester.tk)
 
 ;tags: soup

--- a/src/zopf.md
+++ b/src/zopf.md
@@ -23,6 +23,6 @@
 9. Wait for the bread to cool before cutting.
 
 ## Contribution
-- Thijs Wester - [website](twester.tk)
+- Thijs Wester - [website](https://twester.tk)
 
 ;tags: swiss bread


### PR DESCRIPTION
Someone had a broken link - without the protocol specifier, browsers interpret it as a relative link.