### PR TITLE
Correct grammar and name

### DIFF
--- a/src/gnocchi.md
+++ b/src/gnocchi.md
@@ -21,10 +21,10 @@ They are substantial and can be roasted in butter and other ingredients.
 5. Begin to boil more water with lots of kosher salt added.
 6. Flour a work surface, pinch off some of the dough and roll it on the surface into a long chubby snake.
 7. Slice the dough snake into small pieces. Press the pieces with your finger to make an indentation.
-8. Add the pieces to the boiling water. They will rise to the top when they have ready.
+8. Add the pieces to the boiling water. They will rise to the top when they are ready.
 9. In a pan, melt butter and add sprigs of sage (oregano or thyme will work as well, albeit are less traditional). Smashed tomato juices are also a nice addition.
 10. Add the cooked gnocchi to the pan and roast them in butter for a minute or two until slightly browned. As pan begins to dry, add some pasta water.
-12. Serve gnocchi on a plate, add parmesan cheese liberally. Add garnish if desired.
+12. Serve gnocchi on a plate, grate on Parmigiano-Reggiano cheese liberally. Add garnish if desired.
 
 ## Contribution
 


### PR DESCRIPTION
"Parmesan" is a generic name for the cheese Parmigiano-Regiano. I propose instating the rule that this traditional, authentic cheese must always be preferred over the cheaper, mass-produced "parmesan".

Please see: https://en.wikipedia.org/wiki/Parmigiano-Reggiano

<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
