### PR TITLE
Add index link to top of article

### DIFF
--- a/templates/article_header.html
+++ b/templates/article_header.html
@@ -1,0 +1,1 @@
+<p><a href="/">⟵ Recipe index</a><p>

--- a/templates/tag_index_header.html
+++ b/templates/tag_index_header.html
@@ -1,3 +1,4 @@
+<p><a href="/">⟵ Recipe Index</a></p>
 <div class="banner">
     <h1>🍳 $TITLE 🍲</h1>
     <hr/>


### PR DESCRIPTION
<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->

In reference to #172, where a suggestion was made to have a link at the top to return to the index of recipes. 

Here's how it looks: 
![retvrn](https://user-images.githubusercontent.com/27455314/111529451-8e490300-8738-11eb-9abf-d0df63a971f3.png)
