### PR TITLE
Suggestion to increase line-height

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -6,7 +6,6 @@ body {
 	padding: 0 16px ;
 	margin-bottom: 500px ;
 	font-family: sans-serif ;
-	line-height: 1.5 ;
 }
 
 a {
@@ -81,3 +80,10 @@ img[alt="XMR Logo"] {
 @media (min-width: 100em) {
 	#artlist { column-count: 3 ;}
 }
+
+@media (pointer: coarse) {
+	li {
+		line-height: 1.5 ;
+	}
+}
+

--- a/data/style.css
+++ b/data/style.css
@@ -6,6 +6,7 @@ body {
 	padding: 0 16px ;
 	margin-bottom: 500px ;
 	font-family: sans-serif ;
+	line-height: 1.5 ;
 }
 
 a {


### PR DESCRIPTION
An increased line-height to make it easier for mobile users to click on the links. Also as a bonus makes blocks of text easier to read, both on desktop *and* mobile. The value of 1.5 is good in my opinion, but 1.75 or similar could also work.