### PR TITLE
Add a lightweight inline favicon

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🍳</text></svg>">
         <link rel="stylesheet" href="./style.css">
         <title>$PAGE_TITLE</title>
     </head>


### PR DESCRIPTION
### Issue
Browser will query for a `favicon.ico` if none were specified.

![image](https://user-images.githubusercontent.com/231748/111873887-85e80680-898a-11eb-83f9-1305ea88cd9b.png)

### Solution
Using emoji and SVG we can create a **very light** favicon that is still descriptive of the website and avoid having one more request done to the server for nothing.