### PR TITLE
style.css: increase spacing

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -6,6 +6,7 @@ body {
 	padding: 0 16px ;
 	margin-bottom: 500px ;
 	font-family: sans-serif ;
+	line-height: 1.4 ;
 }
 
 a {
@@ -45,6 +46,10 @@ img[alt="XMR Logo"] {
 	max-width: 1em ;
 	max-height: 1em ;
 	display: inline ;
+}
+
+#artlist {
+	column-gap: 26px ;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
Increase text readability by adding a bit to the line height and a slight gap between columns on the front page. This makes it much easier to read through the whole list of recipes without the words running together.

<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
