### PR TITLE
[Changed at styles.css] Huge, I mean MASSIVE images ruin the exprience

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -29,7 +29,8 @@ footer {
 }
 
 img {
-	max-width: 600px ;
+	padding-left: 120px;
+	max-width: 250px ;
 	width: 100% ;
 	margin: auto ;
 	display: block ;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80398595/111896554-2e49a980-8a23-11eb-9970-b0463f0af6f9.png)



----------------------------
After the my changing it should look like:
![image](https://user-images.githubusercontent.com/80398595/111896699-19b9e100-8a24-11eb-89de-460df5310be8.png)

I think adding a 'checkbox' that let you change the pictures from max-width-250px to 600px 
could be nice too, but I tried it on my smart phone and the images look actually sharper and I was able to follow the recipie better! 
Please consider my change

here is a good page you can try the change 
```https://based.cooking/arroz-chaufa```