### PR TITLE
Revise hummus recipe

### DIFF
--- a/src/hummus.md
+++ b/src/hummus.md
@@ -2,20 +2,32 @@
 
 ## Ingredients
 
-- One can of garbonzo beans
-- About 3 tablespoons of tahini (also known as tehina)
-- A spash of Lemmon Juice
-- A splash of Olive Oil
+- One can of garbanzo beans (chickpeas)
+- 1/2 teaspoon baking soda
+- 1/2 cup of tahini (also known as tehina)
+- 1/4 cup (or more, to taste) of lemon juice, fresh preferred - this is about 1 1/2 to 2 lemons' worth
+- 1 (or 2) clove(s) of garlic, roughly chopped (fresh or frozen pre-chopped is fine, but not dry)
+- 1/4 teaspoon cumin, ground (if you have whole, toast in a dry pan until fragrant before grinding)
+- 1/4 teaspoon za'atar (optional, if you can find it)
+- 1 Tablespoon of olive oil, plus more for serving
+- Fresh parsley (optional for serving)
 
 ## Directions
 
-1. Thuroughly rinse garbonzo beans and remove any skins
-2. Put all ingredients into a small food processor and chop until desired thickness is reached
-3. You may have to add more olive oil or lemmon juice to reach your desired thickness (exact measurements of these ingredients were not given because you may like your hummus to be a different thickness than someone else, feel free to experiment)
-4. Once your desired thickness has been reached place in a sealale container and refrigerate until you are ready to eat
+1. Drain and rinse the garbanzo beans.
+2. Place garbanzo beans in a small saucepan or pot, add 1 teaspoon baking soda (this alters the pH to encourage the beans to break down and shed their skins), and cover with a few inches of water. Bring to a boil and cook for 20 minutes, until the skins begin to fall off and the beans look overcooked/mushy. You may need to reduce the heat after a few minutes to prevent boil-overs.
+3. While the garbanzo beans are boiling, combine the garlic and lemon juice with 1/4 teaspoon salt in the workbowl of your food processor. Pulse until a fine, uniform consistency is achieved. You may need to scrape down the top and sides of the bowl to ensure the garlic is chopped finely enough. Leave the mixture for at least 10 minutes for the raw garlic taste to mellow.
+4. After 20 minutes of boiling, drain the garbanzo beans and their skins in a mesh strainer, then rinse for at least 30 seconds with cold water to remove any lingering taste from the baking soda.
+5. Add the tahini to the food processor. Blend until creamy. Scrape down the sides and bottom of the bowl.
+6. While the food processor is running on "high," slowly drizzle in two tablespoons of ice-cold water. Continue to run on high, scraping down the bowl as necessary (1-3 times), until the mixture has enough air worked into it that it lightens in color and thickens in texture substantially.
+7. Scrape down the bowl again, then add the garbanzo beans and cumin (and za'atar, if you have it). Pulse a few times, then set the food processor to high again. Drizzle in 1 tablespoon of olive oil, as slowly as you can manage.
+8. Continue to process the hummus on high for at least one minute longer, up to three minutes longer if it hasn't become smooth enough yet. You can make the hummus thinner at this point by slowly adding ice water a teaspoon at a time while processing on high. Taste the hummus at this point to determine if it needs more lemon juice or more salt for flavor.
+9. Transfer the hummus into a serving bowl and smooth out the surface with the back of a spoon, creating swirls or indentations for olive oil as desired. Top with additional olive oil and optionally finely chopped fresh parsley, more za'atar, or a sprinkling of sumac (a spice mixture) or dukkah (a seed mixture).
+10. Serve immediately or transfer to an airtight container and store in the refrigerator for up to one week.
 
 ## Contribution
 
 - Jacob Smith - [website](https://jacobwsmith.xyz)
+- K Chesney (revision)
 
 ;tags: basic snack spread


### PR DESCRIPTION
TBH the previous recipe for hummus is not good. When using canned chickpeas, they need to be boiled for about 20 minutes or they won't blend uniformly and you'll end up with little hard bits in the hummus, and it won't whip up and increase in volume properly. If you take this step you can also skip removing the skins, as the baking soda and boiling time breaks them down enough that they disappear completely while blending. The previous recipe didn't include enough tahini, and didn't give useful guidelines for how much lemon juice and olive oil to use, and also skipped the garlic completely.

<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
