### PR TITLE
Format Cinque Pi tags properly

### DIFF
--- a/src/cinque-pi.md
+++ b/src/cinque-pi.md
@@ -28,4 +28,4 @@ This is a nice simple dish made up of five ingredients: panna, pomodori, parmigi
 
 - **Elias Pahls** - [contact](mailto:pahlse@pm.me)
 
-;tags: italian, pasta, quick
+;tags: italian pasta quick


### PR DESCRIPTION
Tags current use ', ' as a seperator, this works, but changing to ' ' brings in line with the rest of the site.