### PR TITLE
Format Baked Mostaccioli tags properly

### DIFF
--- a/src/baked-mostaccioli.md
+++ b/src/baked-mostaccioli.md
@@ -31,4 +31,4 @@ Baked pasta cooked in dish with spicy sauce
 - Recipe created by Dan
 - Refined & Uploaded by Zyansheep.
 
-;tags: pasta, italian
+;tags: pasta italian


### PR DESCRIPTION
Tags current use ', ' as a separator, this works, but changing to ' ' brings in line with the rest of the site.