### PR TITLE
Add recipe for tuhu

### DIFF
--- a/src/tuhu.md
+++ b/src/tuhu.md
@@ -14,7 +14,7 @@ Yale Babylonian Collection from tablets from Babylonia, ca. 1740 BC.
 - 350 mL of prepared water
 - 350 mL of sour-tasting beer (e.g. Weißbier)
 - 1 large onion, chopped
-- 2 cups of aragula, chopped
+- 2 cups of arugula, chopped
 - ¾ cup of cilantro, chopped
 - 2 tsp of cumin seeds, crushed or powdered
 - 2 large beetroots, chopped

--- a/src/tuhu.md
+++ b/src/tuhu.md
@@ -1,0 +1,43 @@
+# Tuh'u
+
+Tuh'u (Akkadian for possibly "beetroot") is an ancient Mesopotamian spring festival dish, extracted by historians at Yale Babylonian Collection
+from tablets from Babylonia, ca. 1740 BC.
+
+- ⏲️ Prep time: 30 min
+- 🍳 Cook time: 60-90 min
+- 🍽️ Servings: 3
+
+## Ingredients
+
+- 450 g of lamb leg meat, diced
+- 4 tbsp of sesame oil, olive oil, or rendered fat
+- 350 mL of prepared water
+- 350 mL of sour-tasting beer (e.g. Weißbier)
+- 1 large onion, chopped
+- 2 cups of aragula, chopped
+- ¾ cup of cilantro, chopped
+- 2 tsp of cumin seeds, crushed or powdered
+- 2 large beetroots, chopped
+- 1 leek, minced or diced
+- 3-9 cloves of garlic, minced or diced
+- 1 Persian shallot (Akkadian: *samidu*; uncertain translation)
+- 1 Egyptian leek (Akkadian: *suhutinnu*; uncertain translation)
+- Coriander seeds for garnish
+
+## Directions
+
+1. Add oil/fat to a large pot (preferably iron) and set over high heat. Sear lamb for several minutes in the oil/fat until lightly browned.
+2. Add onions and cook for 5 minutes
+3. Add beetroots and let cook for 5 minutes.
+4. Add salt, water, beer, arugula, cilantro, shallot, and cumin. Bring to a boil.
+5. Mix garlic with leek and Egyptian leek, and add the mixture to the pot.
+6. Lower heat to medium and let simmer for 60 minutes, or until the beetroot and meat are cooked to your liking.
+7. Once the tuh'u has finished cooking, serve in a bowl. Sprinkle with coriander seeds. Garnish with chopped cilantro and chopped Egyptian leek.
+
+## Contribution
+
+- Tasting History with Max Miller - [website](https://www.youtube.com/channel/UCsaGKqPZnGp_7N80hcHySGQ),
+[video about recipe](https://www.youtube.com/watch?v=7IYYhoO-hiY)
+- Holsterbau - [website](https://github.com/Holsterbau)
+
+;tags: lamb, stew

--- a/src/tuhu.md
+++ b/src/tuhu.md
@@ -40,4 +40,4 @@ Yale Babylonian Collection from tablets from Babylonia, ca. 1740 BC.
 [video about recipe](https://www.youtube.com/watch?v=7IYYhoO-hiY)
 - Holsterbau - [website](https://github.com/Holsterbau)
 
-;tags: lamb, stew
+;tags: lamb stew

--- a/src/tuhu.md
+++ b/src/tuhu.md
@@ -1,7 +1,7 @@
 # Tuh'u
 
-Tuh'u (Akkadian for possibly "beetroot") is an ancient Mesopotamian spring festival dish, extracted by historians at Yale Babylonian Collection
-from tablets from Babylonia, ca. 1740 BC.
+Tuh'u (Akkadian for possibly "beetroot") is an ancient Mesopotamian spring festival dish, a lamb stew of sorts, extracted by historians at
+Yale Babylonian Collection from tablets from Babylonia, ca. 1740 BC.
 
 - ⏲️ Prep time: 30 min
 - 🍳 Cook time: 60-90 min


### PR DESCRIPTION
Tuh'u (Akkadian for possibly "beetroot") is an ancient Mesopotamian spring festival dish, a lamb stew of sorts, extracted by historians at Yale Babylonian Collection from tablets from Babylonia, ca. 1740 BC.