### PR TITLE
Fixed Scandinavian coffee cake recipe formatting error

### DIFF
--- a/src/scandinavian-coffee-cake.md
+++ b/src/scandinavian-coffee-cake.md
@@ -3,7 +3,7 @@
 * ⏲️ Prep time: 15 min
 * 🍳Cook time: ≈ 3 hours
 * 🍽️ Servings: 1 cake
-* 
+
 ## Ingredients
 
 * 1/2 cup milk


### PR DESCRIPTION
Fixed a stray unordered list asterisk, which caused the `## Ingredients` header to render with a bullet point. Now there's a blank line between the first unordered list and the header.