### PR TITLE
Fixes duplicates on tag pages (#354)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ blog/@%.html: $(TAGFILES) $(addprefix templates/,$(addsuffix .html,header tag_in
 	envsubst < templates/tag_index_header.html >> $@; \
 	envsubst < templates/article_list_header.html >> $@; \
 	first=true; \
-	for f in $(shell grep -FH '$*' $(TAGFILES) | sed 's,^tags/\([^:]*\):.*,$(BLOG_SRC)/\1.md,'); do \
+	for f in $(shell awk '$$0 == "$*" { gsub("tags", "$(BLOG_SRC)", FILENAME); print FILENAME  ".md"; nextfile; }' $(TAGFILES)); do \
 		printf '%s ' "$$f"; \
 		git log -n 1 --diff-filter=A --date="format:%s $(BLOG_DATE_FORMAT_INDEX)" --pretty=format:'%ad%n' -- "$$f"; \
 	done | sort | cut -d" " -f1,3- | while IFS=" " read -r FILE DATE; do \


### PR DESCRIPTION
See issue #354. A tag page like `cake` was also using recipes tagged as `pancake` because it contained the word `cake`. Since some pancake recipes were also tagged as cake, they appeared twice.

Solution was to specify that grep look for a line that is the name of a tag, instead of seeing if the line contains the name of a tag.