### PR TITLE
Fix tag separator to allow hyphen separated tags like 'slow-cooked'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ config:
 
 tags/%: $(BLOG_SRC)/%.md
 	mkdir -p tags
-	grep -ih '^; *tags:' "$<" | cut -d: -f2- | tr '[:punct:]' ' ' | sed 's/  */\n/g' | sed '/^$$/d' | sort -u > $@
+	grep -ih '^; *tags:' "$<" | cut -d: -f2- | tr -c '[^a-z\-]' ' ' | sed 's/  */\n/g' | sed '/^$$/d' | sort -u > $@
 
 blog/index.html: index.md $(ARTICLES) $(TAGFILES) $(addprefix templates/,$(addsuffix .html,header index_header tag_list_header tag_entry tag_separator tag_list_footer article_list_header article_entry article_separator article_list_footer index_footer footer))
 	mkdir -p blog


### PR DESCRIPTION
Consider this [chicken-tacos](https://based.cooking/chicken-tacos) recipe.

it has the `slow-cooked` tag on it. But if you click the tag on this page you get taken to a page that doesn't exist because the tagging separates on punctuation, which includes hyphens. So you actually end up with this recipe in a tag called `slow` and a tag called `cooked`.

I changed the `tr` command to use the `-c` option for the complement of SET1, and SET1 is now alpha characters and hyphens. So now tags will be split on characters that aren't alpha or hyphens, which should work for any case we have.

I decided not to do capital letters, because tags shouldn't be capitalized anyways.