### PR TITLE
Fix CI script to fail if each command fails

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -26,7 +26,4 @@ jobs:
         key: ${{ secrets.based_ssh }}
         passphrase: ${{ secrets.based_ssh_pass }}
         port: ${{ secrets.based_port }}
-        script: |
-          cd repo
-          git pull --force origin master
-          make clean deploy
+        script: cd repo && git pull --force origin master && make clean deploy


### PR DESCRIPTION
I am assuming that the `|` after `script:` that was there before was just to have it work over multiple lines?

The idea here is that if the cd fails, or if the git pull fails, or if the make fails then the CI will fail and actually show a red X instead of failing silently if the git pull fails

REF: #413 