### PR TITLE
Improved the PR check script

### DIFF
--- a/.github/workflows/scripts/check-files.sh
+++ b/.github/workflows/scripts/check-files.sh
@@ -40,6 +40,7 @@ check_recipe_content() {
 		BEGIN {
 			HAS_TITLE                   = 0;
 			HAS_TAGS                    = 0;
+			HAS_INVALID_TAGS            = 0;
 			NUM_TAGS                    = 0;
 			HAS_INGREDIENTS             = 0;
 			HAS_DIRECTIONS              = 0;
@@ -78,6 +79,15 @@ check_recipe_content() {
 			if ($1 == ";tags:") {
 				HAS_TAGS = 1;
 				NUM_TAGS = NF - 1;
+
+				# Loop through all the tags
+				for (i = 2; i <= NF; i++) {
+					# Make sure that each tag only contains lowercase letters and hyphens
+					if ($i !~ "^[a-z-]+$") {
+						HAS_INVALID_TAGS = 1;
+						break;
+					}
+				}
 			}
 
 			FAIL = 0;
@@ -90,12 +100,19 @@ check_recipe_content() {
 			if (!HAS_TAGS) {
 				print "Recipe does not have a properly formatted tags on the last line."
 				FAIL = 1;
-			} else if (NUM_TAGS < 2) {
-				print "Recipe only has " NUM_TAGS " tags. Add some more."
-				FAIL = 1;
-			} else if (NUM_TAGS > 5) {
-				print "Recipe has " NUM_TAGS " tags which is too many. Remove some tags."
-				FAIL = 1;
+			} else {
+				if (HAS_INVALID_TAGS) {
+					print "Recipe has invalid tags. Tags must be separated by spaces and contain only lowercase letters or hyphens (-)";
+					FAIL = 1;
+				}
+
+				if (NUM_TAGS < 2) {
+					print "Recipe only has " NUM_TAGS " tags. Add some more."
+					FAIL = 1;
+				} else if (NUM_TAGS > 5) {
+					print "Recipe has " NUM_TAGS " tags which is too many. Remove some tags."
+					FAIL = 1;
+				}
 			}
 
 			if (!HAS_INGREDIENTS) {


### PR DESCRIPTION
I've added some improvements and changes to the PR script. I will explain my changes here:

- Because of  `set -eu`, I can't `exit 1` inside awk because that causes the awk command to fail, which will immediately exit the script. Instead of exiting with an error code inside awk, I just capture the output of awk, and if it isn't empty print all those messages out and set the `FAIL` flag.
- I added a check to the awk command to check for consecutive empty lines since that is something that sometimes comes through PRs
- I changed the `/^# Ingredients` and the directions regexes to check the whole line literally instead, otherwise extra words or the line ending with `:` would get passed.
- Added a check to the awk command to check that the list of tags is only lowercase letters and hyphens
- I Changed how the while loop is called. piping some input to a while loop actually runs the while loop in a subshell, which means that all of the assignments to the global FAIL don't actually carry through to the `exit $FAIL` at the bottom of the file, which can result in the script exiting with no errors when there should be.
- `index.md` is ignored in the PR check, since it is not a recipe.