### PR TITLE
Do not treat `README.md` or `RULES.md` as recipes

### DIFF
--- a/.github/workflows/scripts/check-files.sh
+++ b/.github/workflows/scripts/check-files.sh
@@ -134,6 +134,8 @@ while IFS= read -r file; do
 		# Ignore these files
 		index.md) ;;
 		.github/*.md) ;;
+		README.md) ;;
+		RULES.md) ;;
 
 		*.webp)
 			check_size "$file"


### PR DESCRIPTION
<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
This would get #204 and #319 passing.