### PR TITLE
gotta go fast: don't clean before building

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -30,4 +30,4 @@ jobs:
           cd repo
           git stash
           git pull --force origin master
-          make clean deploy
+          make deploy


### PR DESCRIPTION
<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
Initially, I made blogit to clean everything before rebuilding because the Makefile was still being modified (and rebuild is not triggered by a Maekfile modif). NMow, with the growing number of recipes, it's time to use the Makefile in all its glory and let it decide for itself what to rebuild.