### PR TITLE
Add tag_link template files during makefile init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ init:
 	printf '' > templates/tag_index_footer.html
 	printf '' > templates/article_header.html
 	printf '' > templates/article_footer.html
+	printf '<p><i> Recipe tags: ' > templates/tag_link_header.html
+	printf '<a href="$$TAG_LINK">$$TAG_NAME</a>' > templates/tag_link.html
+	printf '</i></p>' > templates/tag_link_footer.html
+
 	printf 'blog\n' > .git/info/exclude
 
 build: blog/index.html tagpages $(patsubst $(BLOG_SRC)/%.md,blog/%.html,$(ARTICLES)) $(patsubst %,blog/%.xml,$(BLOG_FEEDS))


### PR DESCRIPTION
The below files were added to source in d42399ae92a56146cca72d3421816ae730c26357 however, it looks like they were looked over in the `init` Makefile rule. This PR simply adds them verbatim to the `init` rule.

```shell
templates/tag_link_header.html
templates/tag_link.html
templates/tag_link_footer.html
```
