### PR TITLE
Fixing issue with displying on windows xp

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang=en>
     <head>
         <meta charset="UTF-8">


### PR DESCRIPTION
Fixing an issue with latency and fonts on my windows xp machine

<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
