### PR TITLE
Clarify the use of aluminum foil on the tray.

### DIFF
--- a/src/garlic-toast.md
+++ b/src/garlic-toast.md
@@ -14,7 +14,7 @@ Garlic toast, perfect as a substitute for crackers in a cheese platter.
 ## Directions
 
 1. Preheat oven to 180°C (350°F).
-2. Place sliced bread on a baking tray, covered with aluminium foil
+2. Place sliced bread on a baking tray lined with aluminium foil.
 3. Generously coat bread slices with garlic-infused olive oil.
 4. Season with garlic salt, to taste.
 5. Bake for 10-15 minutes or until crunchy throughout.


### PR DESCRIPTION
Clarifies the use of aluminum foil in this case. For a crispy garlic toast, use foil to line tray. Original recipe could imply covering the toast with foil, which is a valid way to make soft garlic bread, but it does seem that the rest of the recipe is implying the goal is to make the crispy version.