### PR TITLE
Reduce favicon emoji size 90 -> 80

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🍲</text></svg>">
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%221em%22 font-size=%2280%22>🍲</text></svg>">
         <link rel="stylesheet" href="./style.css">
         <title>$PAGE_TITLE</title>
         <meta name="description" content="Only Based cooking. No ads, no tracking, nothing but based cooking.">


### PR DESCRIPTION
Current favicon size clips and gets cropped in certain browsers.
This change decreases the size slightly.
![comparison of favicon before and after size reduction](https://user-images.githubusercontent.com/17160920/113900290-f5088c00-97cd-11eb-94df-6f47c1da5661.png)