### PR TITLE
Add Celsius amount to the crouton recipe

### DIFF
--- a/src/croutons.md
+++ b/src/croutons.md
@@ -12,7 +12,7 @@ Croutons are an essential addition to many salads.  They are delicious and easy 
 
 ## Directions
 
-1. Preheat oven to 350 degrees Fahrenheit (roughly 180 degrees Celsius).  Gently cut slices of white bread into squares with a chef's knife.  One to two slices is usually enough for one person.
+1. Preheat oven to 350°F (roughly 180°C).  Gently cut slices of white bread into squares with a chef's knife.  One to two slices is usually enough for one person.
 2. In a large bowl combine olive oil, spices, and bread squares and gently mix to thoroughly season bread.  Spices can be anything but I recommend oregano, paprika, black pepper, garlic powder or freshly minced garlic, and a small pinch of cayenne.
 3. Spread seasoned bread squares large face down onto a baking sheet evenly and put in oven for 6-8 minutes.  Once the bread has crisped flip each square and put back in oven for another 6-8 minutes or until crispy throughout.
 4. Once fully baked, let rest until cool.  These can be eaten immediately or saved in a sandwich bag for later.

--- a/src/croutons.md
+++ b/src/croutons.md
@@ -12,7 +12,7 @@ Croutons are an essential addition to many salads.  They are delicious and easy 
 
 ## Directions
 
-1. Preheat oven to 350 degrees Fahrenheit.  Gently cut slices of white bread into squares with a chef's knife.  One to two slices is usually enough for one person.
+1. Preheat oven to 350 degrees Fahrenheit (roughly 180 degrees Celsius).  Gently cut slices of white bread into squares with a chef's knife.  One to two slices is usually enough for one person.
 2. In a large bowl combine olive oil, spices, and bread squares and gently mix to thoroughly season bread.  Spices can be anything but I recommend oregano, paprika, black pepper, garlic powder or freshly minced garlic, and a small pinch of cayenne.
 3. Spread seasoned bread squares large face down onto a baking sheet evenly and put in oven for 6-8 minutes.  Once the bread has crisped flip each square and put back in oven for another 6-8 minutes or until crispy throughout.
 4. Once fully baked, let rest until cool.  These can be eaten immediately or saved in a sandwich bag for later.


### PR DESCRIPTION
While yes, 350 °F is technically only 176 °C, no Celsius-based oven has such a setting, and the closest one is 180 °C.

<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
