### PR TITLE
Give some love to the scrollbar.

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -14,6 +14,7 @@ body {
 }
 ::-webkit-scrollbar-thumb {
 	background-color: gray;
+	border-radius: 5px;
 }
 
 a {

--- a/data/style.css
+++ b/data/style.css
@@ -8,6 +8,13 @@ body {
 	font-family: sans-serif ;
 	scrollbar-color: white #151515;
 }
+::-webkit-scrollbar {
+	width: .66vw;
+	background-color: #151515;
+}
+::-webkit-scrollbar-thumb {
+	background-color: white;
+}
 
 a {
 	color: lightblue ;
@@ -53,6 +60,12 @@ img[alt="XMR Logo"] {
 		background: white ;
 		color: black ;
 		scrollbar-color: black white;
+	}
+	::-webkit-scrollbar {
+		background-color: white;
+	}
+	::-webkit-scrollbar-thumb {
+		background-color: black;
 	}
 	a {
 		color: blue ;

--- a/data/style.css
+++ b/data/style.css
@@ -6,14 +6,14 @@ body {
 	padding: 0 16px ;
 	margin-bottom: 500px ;
 	font-family: sans-serif ;
-	scrollbar-color: white #151515;
+	scrollbar-color: gray #151515;
 }
 ::-webkit-scrollbar {
 	width: .66vw;
 	background-color: #151515;
 }
 ::-webkit-scrollbar-thumb {
-	background-color: white;
+	background-color: gray;
 }
 
 a {
@@ -59,13 +59,13 @@ img[alt="XMR Logo"] {
 	body {
 		background: white ;
 		color: black ;
-		scrollbar-color: black white;
+		scrollbar-color: gray white;
 	}
 	::-webkit-scrollbar {
 		background-color: white;
 	}
 	::-webkit-scrollbar-thumb {
-		background-color: black;
+		background-color: gray;
 	}
 	a {
 		color: blue ;

--- a/data/style.css
+++ b/data/style.css
@@ -6,6 +6,7 @@ body {
 	padding: 0 16px ;
 	margin-bottom: 500px ;
 	font-family: sans-serif ;
+	scrollbar-color: white #151515;
 }
 
 a {
@@ -51,6 +52,7 @@ img[alt="XMR Logo"] {
 	body {
 		background: white ;
 		color: black ;
+		scrollbar-color: black white;
 	}
 	a {
 		color: blue ;


### PR DESCRIPTION
Scrollbars deserve attention too. This commit styles the scrollbar according to the current theme (light/dark) using the `scrollbar-color` attribute ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color)). This attribute is currently only supported by Firefox.

EDIT: There's also support for webkit-based browsers (including chrome-based browsers).