### PR TITLE
Fix overlap in recipe list on small devices

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -73,8 +73,8 @@ img[alt="XMR Logo"] {
 
 @media (pointer: coarse) {
 	li > a {
-	    display: block;
-		height: 1.5rem
+	    display: inline-block;
+		padding: 0.2em 0;
 	}
 }
 


### PR DESCRIPTION
While shopping for recipes I noticed that longer names would overflow into the next list item on my cell phone, which was quite annoying.

I fixed the issue by using padding and inline-block instead of the height and block properties of the li>a inside the pointer media query.

I was able to replicate this problem on Firefox Android (12) and chromium-101 (use dev tools to select a mobile viewport; if you click on the "select an element...." button the problem will disappear - no idea why).

Cheers