### PR TITLE
Add vim-like key-bind to search input

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -23,6 +23,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const search = document.querySelector('#search')
   const clearSearch = document.querySelector('.clear-search')
   const artlist = document.getElementById('artlist')
+  
+  document.addEventListener('keydown', function(e) {
+    // if search already focused do nothing
+    if (search === document.activeElement) return;
+
+    // if key pressed is '/'
+    if (e.keyCode ===  191) {
+        search.focus();
+
+        // preventDefault so '/' is not added to search value
+        e.preventDefault();
+    }
+  })
 
   search.addEventListener('input', e => {
     // grab search input value


### PR DESCRIPTION
This simple commit adds an EventListener for when a key is pressed and, if that key is the forward-slash ("/") key, the search input is focused and the user can start typing.

If the search input is already focused, nothing new happens as there is a return statement.

This binding takes inspiration from vim.