### PR TITLE
remove accents from search input and search string

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   search.addEventListener("input", () => {
     // grab search input value
-    const searchText = search.value.toLowerCase().trim();
+    const searchText = search.value.toLowerCase().trim().normalize('NFD').replace(/\p{Diacritic}/gu, "");
     const searchTerms = searchText.split(" ");
     const hasFilter = searchText.length > 0;
 
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // for each recipe hide all but matched
     recipes.forEach(recipe => {
-      const searchString = `${recipe.textContent} ${recipe.dataset.tags}`.toLowerCase();
+      const searchString = `${recipe.textContent} ${recipe.dataset.tags}`.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, "");
       const isMatch = searchTerms.every(term => searchString.includes(term));
 
       recipe.hidden = !isMatch;


### PR DESCRIPTION
Normalizes search text and recipe title/tags so that both the name with the accent included and without accent will find the correct recipe. A search input of "crêpe" will be turned into "crepe". While as previously only searching "crêpe" will find the crepe recipes.