### PR TITLE
Add the sausage tag to Korv Stroganoff

### DIFF
--- a/content/korv-stroganoff.md
+++ b/content/korv-stroganoff.md
@@ -1,6 +1,6 @@
 ---
 title: Korv Stroganoff
-tags: ['swedish', 'quick']
+tags: ['swedish', 'quick', 'sausage']
 date: 2022-07-16
 ---
 


### PR DESCRIPTION
*Korv* is a word from Swedish meaning sausage. The title contains *Korv* so I thought the `sausage` tag would be good.