### PR TITLE
Fixes for zurich-style-meat-saute

### DIFF
--- a/content/zurich-style-meat-saute.md
+++ b/content/zurich-style-meat-saute.md
@@ -38,4 +38,4 @@ and mushrooms.
 7. Add the meat, boil until the meat is warm.
 8. Add parsley, and serve.
 
-Serve with [Rösti](./roesti.md) or other traditional Swiss dish.
+Serve with [Rösti](/roesti) or other traditional Swiss dish.


### PR DESCRIPTION
- fixed broken link at the bottom
- fixed a spelling mistake in the file name (changed sytle to style)